### PR TITLE
Pairing/day1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 target/
 project/target
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM p7hb/docker-spark:2.1.0
+
+# Prepare SBT and dependencies with temporary project snapshot
+RUN mkdir /root/web-model
+ADD . /root/web-model
+RUN cd /root/web-model && sbt compile
+
+# Mount actual project
+VOLUME /root/web-model
+

--- a/README.md
+++ b/README.md
@@ -2,12 +2,24 @@
 
 ## Quickstart
 
+First, in order to always have a stable Spark environment, create a Docker image. It will take some time, but should be done only once.
+
 ```shell
 $ docker build -t "web-model:0.0.1" .
+```
+
+Next launch just created image as a container and `spark-shell` to start you experiments:
+
+```shell
 $ docker run --rm -it -p 4040:4040 -p 8080:8080 -p 8081:8081 -h spark -v $(pwd):/root/web-model --name=spark web-model:0.0.1
 $ spark-shell --jars /root/web-model/target/scala-2.11/spark-web-model-0.1.0-rc1.jar
+```
+
+In `spark-shell` you can read your data and start testing modeling functions:
+
+```shell
 scala> import org.apache.spark.sql.{DataFrame, SparkSession}
-scala> val spark = SparkSession.builder().getOrCreate()
 scala> import com.snowplowanalytics.snowplow.webmodel.WebModel
-scala> val enrichedData = sc.textFile("/root/web-model/data/snplow6-2017-11-13.gz")
+scala> val spark = SparkSession.builder().getOrCreate()
+scala> val atomicData = WebModel.getAtomicData(sc, spark, "/root/web-model/data/snplow6-2017-11-13.gz")
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Snowplow Spark Web Model
+
+## Quickstart
+
+```shell
+$ docker build -t "web-model:0.0.1" .
+$ docker run --rm -it -p 4040:4040 -p 8080:8080 -p 8081:8081 -h spark -v $(pwd):/root/web-model --name=spark web-model:0.0.1
+$ spark-shell --jars /root/web-model/target/scala-2.11/spark-web-model-0.1.0-rc1.jar
+scala> import org.apache.spark.sql.{DataFrame, SparkSession}
+scala> val spark = SparkSession.builder().getOrCreate()
+scala> import com.snowplowanalytics.snowplow.webmodel.WebModel
+scala> val enrichedData = sc.textFile("/root/web-model/data/snplow6-2017-11-13.gz")
+```


### PR DESCRIPTION
Hey @dilyand,

I just started to work on DataFrame API today and here's a first result. This PR consists of two parts:

1. Docker image. You can ignore it, but long story short - it allows you to play with Spark job on always-identical environment and without installing Spark and other stuff on your machine (but requires Docker haha). Next time we won't need to spend time on submitting it to EMR.
2. Actual DataFrame API. I refactored first function `scratchWebPageContext` (new version called `scratchWebPageContextDf`). It uses very similar to [SQL interface](https://github.com/dilyand/spark-web-model/compare/master...chuwy:pairing/day1?expand=1#diff-75e2b70441fc8ed4b28fca6316c33f6cR52), but a) little bit more type-safe and concise; b) returns `DataFrame` instead of relying on spark session.

Next time, I think we can work through these changes, continue to re-write other functions to DataFrame API and end up with DataSet API.